### PR TITLE
Fix tabs not working in new post preview

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -37,7 +37,7 @@ app.initializers.add('fof/bbcode-tabs', () => {
   };
 
   extend(CommentPost.prototype, ['oncreate', 'onupdate'], createTabs);
-  extend(ComposerPostPreview.prototype, 'oncreate', function () {
+  extend(ComposerPostPreview.prototype, ['oncreate', 'onupdate'], function () {
     extend(this.attrs, 'surround', () => createTabs.call(this));
   });
 });


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Following from investigating #23, the tabs weren't being handled by the JS in a new CommentPostPreview.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- ~~Backend changes: tests are green (run `composer test`).~~